### PR TITLE
Release 1.2.1

### DIFF
--- a/view/frontend/layout/bluefinchcheckout_checkout_index.xml
+++ b/view/frontend/layout/bluefinchcheckout_checkout_index.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
+        <remove src="css/styles.css"/>
         <remove src="css/styles-m.css"/>
         <remove src="css/styles-l.css"/>
         <remove src="requirejs/require.js"/>


### PR DESCRIPTION
Patch release 1.2.1 required to remove stylesheet added to the checkout by the Hyva theme, for checkout compatibility with the Hyva theme.

Original work in https://github.com/BlueFinchCommerce/module-checkout/pull/16