### PR TITLE
Fixed issue with missing translation in admin designer

### DIFF
--- a/view/adminhtml/web/js/checkout/src/components/Steps/CustomerInfoPage/Addresses/AddressForms/BillingForm/BillingForm.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/CustomerInfoPage/Addresses/AddressForms/BillingForm/BillingForm.vue
@@ -147,11 +147,14 @@ export default {
   },
   computed: {
     ...mapState(useCartStore, ['cart', 'isLoggedIn']),
-    ...mapState(useConfigStore, ['addressFinder']),
+    ...mapState(useConfigStore, ['addressFinder', 'locale']),
     ...mapState(useCustomerStore, ['customer', 'emailEntered', 'selected', 'isUsingSavedBillingAddress']),
     ...mapState(useShippingMethodsStore, ['isClickAndCollect']),
   },
-  mounted() {
+  async mounted() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
     this.newAddressText = window.bluefinchCheckout?.[this.newAddressTextId]
     || this.$t('yourDetailsSection.deliverySection.newAddressTitle');
 
@@ -161,6 +164,7 @@ export default {
     document.removeEventListener(this.newAddressTextId, this.setNewAddressText);
   },
   methods: {
+    ...mapActions(useConfigStore, ['getInitialConfig']),
     ...mapActions(useCustomerStore, [
       'setAddressAsEditing',
       'createNewAddress',

--- a/view/adminhtml/web/js/checkout/src/components/Steps/CustomerInfoPage/Addresses/AddressList/AddressList.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/CustomerInfoPage/Addresses/AddressList/AddressList.vue
@@ -56,6 +56,7 @@
 
 // stores
 import { mapActions, mapState } from 'pinia';
+import useConfigStore from '@/stores/ConfigStores/ConfigStore';
 import useCustomerStore from '@/stores/CustomerStore';
 
 // icons
@@ -98,6 +99,7 @@ export default {
     };
   },
   computed: {
+    ...mapState(useConfigStore, ['locale']),
     ...mapState(useCustomerStore, ['customer', 'selected']),
   },
   watch: {
@@ -111,7 +113,11 @@ export default {
       },
     },
   },
-  mounted() {
+  async mounted() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
+
     this.$emit('showAddressBlock', false);
 
     let selectedId = null;
@@ -143,6 +149,7 @@ export default {
     document.removeEventListener(this.addNewAddressButtonTextId, this.setAddNewAddressButtonText);
   },
   methods: {
+    ...mapActions(useConfigStore, ['getInitialConfig']),
     ...mapActions(useCustomerStore, [
       'setAddressToStore',
       'createNewAddress',

--- a/view/adminhtml/web/js/checkout/src/components/Steps/CustomerInfoPage/Addresses/SavedDeliveryAddess/SavedDeliveryAddess.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/CustomerInfoPage/Addresses/SavedDeliveryAddess/SavedDeliveryAddess.vue
@@ -63,8 +63,13 @@ export default {
   },
   computed: {
     ...mapState(useCartStore, ['cart']),
+    ...mapState(useConfigStore, ['locale']),
   },
   async created() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
+
     this.detailStepText = window.bluefinchCheckout?.[this.detailStepTextId] || this.$t('yourDetailsSection.title');
 
     document.addEventListener(this.detailStepTextId, this.setDetailStepText);

--- a/view/adminhtml/web/js/checkout/src/components/Steps/CustomerInfoPage/DividerComponent/DividerComponent.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/CustomerInfoPage/DividerComponent/DividerComponent.vue
@@ -13,7 +13,8 @@
   </div>
 </template>
 <script>
-import { mapState } from 'pinia';
+import { mapActions, mapState } from 'pinia';
+import useConfigStore from '@/stores/ConfigStores/ConfigStore';
 import usePaymentStore from '@/stores/PaymentStores/PaymentStore';
 
 import TextField from '@/components/Core/ContentComponents/TextField/TextField.vue';
@@ -30,9 +31,14 @@ export default {
     };
   },
   computed: {
+    ...mapState(useConfigStore, ['locale']),
     ...mapState(usePaymentStore, ['availableMethods', 'isExpressPaymentsVisible']),
   },
-  mounted() {
+  async mounted() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
+
     this.dividerText = window.bluefinchCheckout?.[this.dividerTextId] || this.$t('dividerText');
 
     document.addEventListener(this.dividerTextId, this.setDividerText);
@@ -41,6 +47,7 @@ export default {
     document.removeEventListener(this.dividerTextId, this.setDividerText);
   },
   methods: {
+    ...mapActions(useConfigStore, ['getInitialConfig']),
     setDividerText(event) {
       this.dividerText = event?.detail?.value || this.$t('dividerText');
     },

--- a/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/CouponDiscount/CouponDiscount.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/CouponDiscount/CouponDiscount.vue
@@ -118,6 +118,10 @@ export default {
     };
   },
   async created() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
+
     this.applyButtonText = window.bluefinchCheckout?.[this.applyButtonTextId] || this.$t('orderSummary.applyBtn');
     this.removeButtonText = window.bluefinchCheckout?.[this.removeButtonTextId] || this.$t('orderSummary.removeBtn');
     this.couponDiscountText = window.bluefinchCheckout?.[this.couponDiscountTextId]
@@ -138,6 +142,7 @@ export default {
   computed: {
     ...mapState(useCartStore, ['cart', 'discountErrorMessage']),
     ...mapWritableState(useCartStore, ['discountCode']),
+    ...mapState(useConfigStore, ['locale']),
     CouponCodeIcon() {
       return `${getStaticUrl(CouponCode)}`;
     },

--- a/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryItem/RemoveItemButton/RemoveItemButton.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryItem/RemoveItemButton/RemoveItemButton.vue
@@ -22,7 +22,7 @@
 import TextField from '@/components/Core/ContentComponents/TextField/TextField.vue';
 
 // stores
-import { mapActions } from 'pinia';
+import { mapActions, mapState } from 'pinia';
 import useCartStore from '@/stores/CartStore';
 import useConfigStore from '@/stores/ConfigStores/ConfigStore';
 
@@ -46,7 +46,14 @@ export default {
       removeItemTextId: 'bluefinch-checkout-removeitem-text',
     };
   },
+  computed: {
+    ...mapState(useConfigStore, ['locale']),
+  },
   async created() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
+
     this.removeItemText = window.bluefinchCheckout?.[this.removeItemTextId] || this.$t('orderSummary.removeItemButton');
 
     document.addEventListener(this.removeItemTextId, this.setRemoveItemText);

--- a/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryMobile/OrderSummaryMobile.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryMobile/OrderSummaryMobile.vue
@@ -140,9 +140,13 @@ export default {
   },
   computed: {
     ...mapState(useCartStore, ['cartGrandTotal', 'getCartItemsQty']),
-    ...mapState(useConfigStore, ['storeCode']),
+    ...mapState(useConfigStore, ['locale', 'storeCode']),
   },
   async created() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
+
     this.orderSummaryText = window.bluefinchCheckout?.[this.orderSummaryTextId] || this.$t('orderSummary.modalHeader');
     this.orderSummaryDescriptionText = window.bluefinchCheckout?.[this.orderSummaryDescriptionTextId]
       || this.$t('orderSummary.mobileDiscountText');

--- a/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryTitleWithAmount/OrderSummaryTitleWithAmount.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryTitleWithAmount/OrderSummaryTitleWithAmount.vue
@@ -8,7 +8,7 @@
 </template>
 <script>
 // stores
-import { mapActions } from 'pinia';
+import { mapActions, mapState } from 'pinia';
 import useConfigStore from '@/stores/ConfigStores/ConfigStore';
 
 // components
@@ -26,7 +26,14 @@ export default {
       orderSummaryTextId: 'bluefinch-checkout-ordersummary-text',
     };
   },
+  computed: {
+    ...mapState(useConfigStore, ['locale']),
+  },
   async created() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
+
     this.orderSummaryText = window.bluefinchCheckout?.[this.orderSummaryTextId] || this.$t('orderSummary.modalHeader');
 
     document.addEventListener(this.orderSummaryTextId, this.setOrderSummaryText);

--- a/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryTotal/OrderSummaryTotal.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryTotal/OrderSummaryTotal.vue
@@ -101,10 +101,14 @@ export default {
   },
   computed: {
     ...mapState(useCartStore, ['cart', 'cartGrandTotal', 'getCartItemsQty', 'getGiftWrappingTotal']),
-    ...mapState(useConfigStore, ['taxCartDisplayFullSummary']),
+    ...mapState(useConfigStore, ['locale', 'taxCartDisplayFullSummary']),
     ...mapState(useShippingMethodsStore, ['selectedMethod']),
   },
   async created() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
+
     this.orderSummaryText = window.bluefinchCheckout?.[this.orderSummaryTextId] || this.$t('orderSummary.modalHeader');
     this.grandTotalText = window.bluefinchCheckout?.[this.grandTotalTextId] || this.$t('orderSummary.grandTotalTitle');
 

--- a/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/PromotionComponent/PromotionComponent.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/PromotionComponent/PromotionComponent.vue
@@ -140,12 +140,16 @@ export default {
     };
   },
   computed: {
+    ...mapState(useConfigStore, ['locale']),
     ...mapState(useCartStore, ['crosssells', 'freeShipping', 'amastyEnabled']),
     promoIconUrl() {
       return `${getStaticUrl(promoSvg)}`;
     },
   },
   async created() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
     this.crossSellsText = window.bluefinchCheckout?.[this.crossSellsTextId]
      || this.$t('orderSummary.crossSellsTitle');
 

--- a/view/adminhtml/web/js/checkout/src/components/Steps/PaymentPage/SavedShippingMethod/SavedShippingMethod.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/PaymentPage/SavedShippingMethod/SavedShippingMethod.vue
@@ -70,7 +70,14 @@ export default {
       shippingStepCompletedTextId: 'bluefinch-checkout-shippingstepcompleted-text',
     };
   },
+  computed: {
+    ...mapState(useConfigStore, ['locale']),
+  },
   async created() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
+
     this.shippingStepCompletedText = window.bluefinchCheckout?.[this.shippingStepCompletedTextId]
       || this.$t('shippingStep.stepCompleteTitle');
 

--- a/view/adminhtml/web/js/checkout/src/components/Steps/ShippingPage/ShippingMethod/ShippingMethod.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/ShippingPage/ShippingMethod/ShippingMethod.vue
@@ -160,7 +160,7 @@ export default {
   },
   computed: {
     ...mapState(useCartStore, ['cart']),
-    ...mapState(useConfigStore, ['taxCartDisplayShipping']),
+    ...mapState(useConfigStore, ['locale', 'taxCartDisplayShipping']),
     ...mapState(useCustomerStore, ['selected']),
     ...mapState(useShippingMethodsStore, [
       'getError',
@@ -170,6 +170,10 @@ export default {
     ]),
   },
   async created() {
+    if (!this.locale) {
+      await this.getInitialConfig();
+    }
+
     this.additionalShippingMethods = Object.keys(shippingMethods());
 
     this.shippingStepText = window.bluefinchCheckout?.[this.shippingStepTextId] || this.$t('shippingStep.stepTitle');


### PR DESCRIPTION
Previously the locale had to exist in localStorage otherwise the translations would fail to load in. In the admin interface this localStorage isn't guaranteed so would sometimes fail to show the translations.

The fix is to check for 'locale' in the config store and if it doesn't exist then we have to wait for the initial config request to finished before doing all the translations.

<!-- 

Do not commit any changes to the `view/frontend/web/js/checkout/dist` directory 

See .github/CONTRIBUTING.md for local workflow recommendations

-->
