### PR TITLE
Fixing duplicate key lint error in admin designer saved shipping method component

### DIFF
--- a/view/adminhtml/web/js/checkout/src/components/Steps/PaymentPage/SavedShippingMethod/SavedShippingMethod.vue
+++ b/view/adminhtml/web/js/checkout/src/components/Steps/PaymentPage/SavedShippingMethod/SavedShippingMethod.vue
@@ -70,9 +70,6 @@ export default {
       shippingStepCompletedTextId: 'bluefinch-checkout-shippingstepcompleted-text',
     };
   },
-  computed: {
-    ...mapState(useConfigStore, ['locale']),
-  },
   async created() {
     if (!this.locale) {
       await this.getInitialConfig();
@@ -88,6 +85,7 @@ export default {
   },
   computed: {
     ...mapState(useCartStore, ['cart']),
+    ...mapState(useConfigStore, ['locale']),
     ...mapState(useShippingMethodsStore, ['selectedMethod']),
   },
   methods: {


### PR DESCRIPTION
Removing the accidental duplication of the computed key which is triggering  a lint error.

<!-- 

Do not commit any changes to the `view/frontend/web/js/checkout/dist` directory 

See .github/CONTRIBUTING.md for local workflow recommendations

-->
