### PR TITLE
Removing the escaping of the google analytics config from template

### DIFF
--- a/view/frontend/templates/gtag_ga.phtml
+++ b/view/frontend/templates/gtag_ga.phtml
@@ -34,7 +34,7 @@ switch ($accountType) {
                     document.addEventListener('user:allowed:save:cookie', function () {
                         window.bluefinchInitGtm(config);
                     });
-                })(<?= $escaper->escapeJs($block->getTagManagerData()) ?>)
+                })(<?= /* @noEscape */ $block->getTagManagerData() ?>)
             </script>
             <!-- END GOOGLE TAG MANAGER -->
             <?php
@@ -61,7 +61,7 @@ switch ($accountType) {
                     document.addEventListener('user:allowed:save:cookie', function () {
                         window.bluefinchInitGtm(config);
                     });
-                })(<?= $escaper->escapeJs($block->getAnalyticsData()) ?>)
+                })(<?= /* @noEscape */ $block->getAnalyticsData() ?>)
             </script>
             <!-- END GOOGLE ANALYTICS 4 CODE -->
             <?php


### PR DESCRIPTION
The following error was being reported in the browser console: `Uncaught SyntaxError: Invalid or unexpected token (at checkout/:88:20)`, which was related to the rendering of the json config into the page incorrectly, meaning Google Analytics (for both Google Tag Manager and GA4) was not instantiating so broken. Events were not firing and so the`dataLayer` was not being populated correctly.

Removing the escaping of the google analytics config from the template fixes this issue.

<!-- 

Do not commit any changes to the `view/frontend/web/js/checkout/dist` directory 

See .github/CONTRIBUTING.md for local workflow recommendations

-->
