### PR TITLE
Always set region to prevent address merging

### DIFF
--- a/view/frontend/web/js/checkout/src/services/addresses/getShippingMethods.js
+++ b/view/frontend/web/js/checkout/src/services/addresses/getShippingMethods.js
@@ -11,7 +11,7 @@ import functionExtension from '@/extensions/functionExtension';
 const convertBoolean = (value) => (value === 1);
 
 const mapToGraphQLString = (obj) => Object.entries(obj)
-  .map(([key, value]) => (value ? `${key}: ${JSON.stringify(value)}` : ''))
+  .map(([key, value]) => (value || value === '' ? `${key}: ${JSON.stringify(value)}` : ''))
   .join(', ');
 
 const buildShippingAddressMutation = async (cartId, formattedAddressGraphQL) => `
@@ -50,7 +50,7 @@ export default async (shippingAddress, paymentMethod = null, express = false) =>
     company: formattedShippingAddress.company,
     street: formattedShippingAddress.street,
     city: formattedShippingAddress.city,
-    region: formattedShippingAddress.region,
+    region: formattedShippingAddress.region || '',
     region_id: formattedShippingAddress.region_id || null,
     postcode: formattedShippingAddress.postcode,
     country_code: formattedShippingAddress.country_code

--- a/view/frontend/web/js/checkout/src/services/addresses/setAddressesOnCart.js
+++ b/view/frontend/web/js/checkout/src/services/addresses/setAddressesOnCart.js
@@ -24,7 +24,7 @@ const formatAddress = (address) => {
   }
 
   if (!clonedAddress.region) {
-    delete clonedAddress.region;
+    clonedAddress.region = '';
   }
 
   // Preserving save_in_address_book before deletion


### PR DESCRIPTION
### Issue
When using the graphQL mutations to set an address, if you don't pass a region it will take any existing region and use that for the new address. This can lead to issues where countries that don't require a region having an old region being saved to the customers shipping/billing address.

### Fix
By sending an empty string for the region if none is entered by the User it will always clear off the old region and save no data for this new address.