### PR TITLE
PCI DSS v4 CSP compliance

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -20,5 +20,20 @@
                 <customer_create_success/>
             </type_for>
         </recaptcha_frontend>
+        <csp>
+            <mode>
+                <storefront_bluefinchcheckout_checkout_index>
+                    <report_only>0</report_only>
+                </storefront_bluefinchcheckout_checkout_index>
+            </mode>
+            <policies>
+                <storefront_bluefinchcheckout_checkout_index>
+                    <scripts>
+                        <inline>0</inline>
+                        <event_handlers>1</event_handlers>
+                    </scripts>
+                </storefront_bluefinchcheckout_checkout_index>
+            </policies>
+        </csp>
     </default>
 </config>

--- a/view/frontend/templates/bluefinch-checkout.phtml
+++ b/view/frontend/templates/bluefinch-checkout.phtml
@@ -17,7 +17,7 @@ $fontFamily = $assetViewModel->getFontFamily();
 
 ?>
 
-<?php $scriptStringJsNamesSpace = <<<script
+<?php $scriptString = <<<script
 
     window.bluefinchCheckout = window.bluefinchCheckout || {};
     window.bluefinchCheckout.magentoEdition = "{$escaper->escapeJs($assetViewModel->getMagentoEdition())}";
@@ -31,14 +31,14 @@ $fontFamily = $assetViewModel->getFontFamily();
 script;
     if ($customWordings):
         foreach (json_decode($customWordings) as $key => $value):
-            $scriptStringJsNamesSpace .= <<<script
+            $scriptString .= <<<script
     window.bluefinchCheckout["{$escaper->escapeJs($key)}"] = "{$escaper->escapeJs($value)}";
 
 script;
         endforeach;
     endif;
 ?>
-<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptStringJsNamesSpace, false) ?>
+<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
 
 <link href="<?= $escaper->escapeHtmlAttr($block->getViewFileUrl('BlueFinch_Checkout::css/checkout.css')) ?>" rel="stylesheet" media="all" />
 
@@ -59,18 +59,18 @@ script;
 
 <?php
 $mainJsAsset = $jsAssets['main'][0];
-$scriptStringJsNamesSpaceMain = <<<script
+$scriptString = <<<script
 
     window.bluefinchCheckout.main = "{$escaper->escapeJs($mainJsAsset->getUrl())}";
 
 script;
 ?>
-<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptStringJsNamesSpaceMain, false) ?>
+<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
 
 <script defer type="module" src="<?= $escaper->escapeHtmlAttr($mainJsAsset->getUrl()); ?>"></script>
 
 <?php
-$scriptStringJsNamesSpaceStaticPath = <<<script
+$scriptString = <<<script
 
     window.bluefinchCheckout.staticPath =
         window.bluefinchCheckout.staticPath.replace(
@@ -80,7 +80,7 @@ $scriptStringJsNamesSpaceStaticPath = <<<script
 
 script;
 ?>
-<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptStringJsNamesSpaceStaticPath, false) ?>
+<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
 
 <?php if (array_key_exists('imports', $jsAssets)): ?>
     <?php foreach ($jsAssets['imports'] as $jsAsset): ?>

--- a/view/frontend/templates/bluefinch-checkout.phtml
+++ b/view/frontend/templates/bluefinch-checkout.phtml
@@ -3,6 +3,7 @@
  * @var \Magento\Catalog\Block\Product\View $block
  * @var \Magento\Framework\Escaper $escaper
  * @var \BlueFinch\Checkout\ViewModel\Assets $assetViewModel
+ *  @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 $assetViewModel = $block->getAssetViewModel();
 $jsAssets = $assetViewModel->getAssetsByType('js');
@@ -16,22 +17,28 @@ $fontFamily = $assetViewModel->getFontFamily();
 
 ?>
 
-<script>
-    window.bluefinchCheckout = window.bluefinchCheckout || {};
-    window.bluefinchCheckout.magentoEdition = "<?= $escaper->escapeJs($assetViewModel->getMagentoEdition()); ?>";
+<?php $scriptStringJsNamesSpace = <<<script
 
-    window.bluefinchCheckout.staticPath = "<?= $escaper->escapeJs($assetViewModel->getDistViewFileUrl('BlueFinch_Checkout::js/checkout/dist/')) ?>";
-    window.bluefinchCheckout.logo = "<?= $escaper->escapeJs($logo); ?>";
+    window.bluefinchCheckout = window.bluefinchCheckout || {};
+    window.bluefinchCheckout.magentoEdition = "{$escaper->escapeJs($assetViewModel->getMagentoEdition())}";
+
+    window.bluefinchCheckout.staticPath = "{$escaper->escapeJs($assetViewModel->getDistViewFileUrl('BlueFinch_Checkout::js/checkout/dist/'))}";
+    window.bluefinchCheckout.logo = "{$escaper->escapeJs($logo)}";
     window.bluefinchCheckout.belowEmailFields = window.bluefinchCheckout.belowEmailFields || {};
     window.bluefinchCheckout.paymentMethods = window.bluefinchCheckout.paymentMethods || {};
     window.bluefinchCheckout.shippingMethods = window.bluefinchCheckout.shippingMethods || {};
 
-    <?php if ($customWordings): ?>
-        <?php foreach (json_decode($customWordings) as $key => $value): ?>
-            window.bluefinchCheckout["<?= $escaper->escapeJs($key) ?>"] = "<?= $escaper->escapeJs($value) ?>";
-        <?php endforeach; ?>
-    <?php endif; ?>
-</script>
+script;
+    if ($customWordings):
+        foreach (json_decode($customWordings) as $key => $value):
+            $scriptStringJsNamesSpace .= <<<script
+    window.bluefinchCheckout["{$escaper->escapeJs($key)}"] = "{$escaper->escapeJs($value)}";
+
+script;
+        endforeach;
+    endif;
+?>
+<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptStringJsNamesSpace, false) ?>
 
 <link href="<?= $escaper->escapeHtmlAttr($block->getViewFileUrl('BlueFinch_Checkout::css/checkout.css')) ?>" rel="stylesheet" media="all" />
 
@@ -50,20 +57,30 @@ $fontFamily = $assetViewModel->getFontFamily();
     <link rel="stylesheet" media="all" href="<?= $escaper->escapeHtmlAttr($cssAsset->getUrl()); ?>">
 <?php endforeach; ?>
 
-<?php foreach ($jsAssets['main'] as $jsAsset): ?>
-    <script>
-        window.bluefinchCheckout.main = "<?= $escaper->escapeUrl($jsAsset->getUrl()) ?>";
-    </script>
-    <script defer type="module" src="<?= $escaper->escapeHtmlAttr($jsAsset->getUrl()); ?>"></script>
-<?php endforeach; ?>
+<?php
+$mainJsAsset = $jsAssets['main'][0];
+$scriptStringJsNamesSpaceMain = <<<script
 
-<script>
+    window.bluefinchCheckout.main = "{$escaper->escapeJs($mainJsAsset->getUrl())}";
+
+script;
+?>
+<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptStringJsNamesSpaceMain, false) ?>
+
+<script defer type="module" src="<?= $escaper->escapeHtmlAttr($mainJsAsset->getUrl()); ?>"></script>
+
+<?php
+$scriptStringJsNamesSpaceStaticPath = <<<script
+
     window.bluefinchCheckout.staticPath =
         window.bluefinchCheckout.staticPath.replace(
             /(.+)\/BlueFinch_Checkout\//,
             window.bluefinchCheckout.main.replace(/(\/BlueFinch_Checkout.+)/, '') + '/BlueFinch_Checkout/'
         );
-</script>
+
+script;
+?>
+<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptStringJsNamesSpaceStaticPath, false) ?>
 
 <?php if (array_key_exists('imports', $jsAssets)): ?>
     <?php foreach ($jsAssets['imports'] as $jsAsset): ?>

--- a/view/frontend/web/js/checkout/package-lock.json
+++ b/view/frontend/web/js/checkout/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "checkout",
+      "name": "bluefinchCheckout",
       "version": "0.0.0",
       "dependencies": {
         "@googlemaps/js-api-loader": "^1.16.6",
@@ -24,7 +24,7 @@
         "vite": "^4.1.2",
         "vue": "^3.4.20",
         "vue-axios": "^3.4.1",
-        "vue-i18n": "^9.1.10",
+        "vue-i18n": "^10.0.6",
         "vue-router": "^4.0.13"
       },
       "devDependencies": {
@@ -2631,12 +2631,13 @@
       "dev": true
     },
     "node_modules/@intlify/core-base": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.9.1.tgz",
-      "integrity": "sha512-qsV15dg7jNX2faBRyKMgZS8UcFJViWEUPLdzZ9UR0kQZpFVeIpc0AG7ZOfeP7pX2T9SQ5jSiorq/tii9nkkafA==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.6.tgz",
+      "integrity": "sha512-/NINGvy7t8qSCyyuqMIPmHS6CBQjqPIPVOps0Rb7xWrwwkwHJKtahiFnW1HC4iQVhzoYwEW6Js0923zTScLDiA==",
+      "license": "MIT",
       "dependencies": {
-        "@intlify/message-compiler": "9.9.1",
-        "@intlify/shared": "9.9.1"
+        "@intlify/message-compiler": "10.0.6",
+        "@intlify/shared": "10.0.6"
       },
       "engines": {
         "node": ">= 16"
@@ -2646,11 +2647,12 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.9.1.tgz",
-      "integrity": "sha512-zTvP6X6HeumHOXuAE1CMMsV6tTX+opKMOxO1OHTCg5N5Sm/F7d8o2jdT6W6L5oHUsJ/vvkGefHIs7Q3hfowmsA==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.6.tgz",
+      "integrity": "sha512-QcUYprK+e4X2lU6eJDxLuf/mUtCuVPj2RFBoFRlJJxK3wskBejzlRvh1Q0lQCi9tDOnD4iUK1ftcGylE3X3idA==",
+      "license": "MIT",
       "dependencies": {
-        "@intlify/shared": "9.9.1",
+        "@intlify/shared": "10.0.6",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -2661,9 +2663,10 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.9.1.tgz",
-      "integrity": "sha512-b3Pta1nwkz5rGq434v0psHwEwHGy1pYCttfcM22IE//K9owbpkEvFptx9VcuRAxjQdrO2If249cmDDjBu5wMDA==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.6.tgz",
+      "integrity": "sha512-2xqwm05YPpo7TM//+v0bzS0FWiTzsjpSMnWdt7ZXs5/ZfQIedSuBXIrskd8HZ7c/cZzo1G9ALHTksnv/74vk/Q==",
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -17681,12 +17684,13 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
     },
     "node_modules/vue-i18n": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.9.1.tgz",
-      "integrity": "sha512-xyQ4VspLdNSPTKBFBPWa1tvtj+9HuockZwgFeD2OhxxXuC2CWeNvV4seu2o9+vbQOyQbhAM5Ez56oxUrrnTWdw==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.6.tgz",
+      "integrity": "sha512-pQPspK5H4srzlu+47+HEY2tmiY3GyYIvSPgSBdQaYVWv7t1zj1t9p1FvHlxBXyJ17t9stG/Vxj+pykrvPWBLeQ==",
+      "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "9.9.1",
-        "@intlify/shared": "9.9.1",
+        "@intlify/core-base": "10.0.6",
+        "@intlify/shared": "10.0.6",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {
@@ -20168,27 +20172,27 @@
       "dev": true
     },
     "@intlify/core-base": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.9.1.tgz",
-      "integrity": "sha512-qsV15dg7jNX2faBRyKMgZS8UcFJViWEUPLdzZ9UR0kQZpFVeIpc0AG7ZOfeP7pX2T9SQ5jSiorq/tii9nkkafA==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.6.tgz",
+      "integrity": "sha512-/NINGvy7t8qSCyyuqMIPmHS6CBQjqPIPVOps0Rb7xWrwwkwHJKtahiFnW1HC4iQVhzoYwEW6Js0923zTScLDiA==",
       "requires": {
-        "@intlify/message-compiler": "9.9.1",
-        "@intlify/shared": "9.9.1"
+        "@intlify/message-compiler": "10.0.6",
+        "@intlify/shared": "10.0.6"
       }
     },
     "@intlify/message-compiler": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.9.1.tgz",
-      "integrity": "sha512-zTvP6X6HeumHOXuAE1CMMsV6tTX+opKMOxO1OHTCg5N5Sm/F7d8o2jdT6W6L5oHUsJ/vvkGefHIs7Q3hfowmsA==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.6.tgz",
+      "integrity": "sha512-QcUYprK+e4X2lU6eJDxLuf/mUtCuVPj2RFBoFRlJJxK3wskBejzlRvh1Q0lQCi9tDOnD4iUK1ftcGylE3X3idA==",
       "requires": {
-        "@intlify/shared": "9.9.1",
+        "@intlify/shared": "10.0.6",
         "source-map-js": "^1.0.2"
       }
     },
     "@intlify/shared": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.9.1.tgz",
-      "integrity": "sha512-b3Pta1nwkz5rGq434v0psHwEwHGy1pYCttfcM22IE//K9owbpkEvFptx9VcuRAxjQdrO2If249cmDDjBu5wMDA=="
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.6.tgz",
+      "integrity": "sha512-2xqwm05YPpo7TM//+v0bzS0FWiTzsjpSMnWdt7ZXs5/ZfQIedSuBXIrskd8HZ7c/cZzo1G9ALHTksnv/74vk/Q=="
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -31240,12 +31244,12 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
     },
     "vue-i18n": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.9.1.tgz",
-      "integrity": "sha512-xyQ4VspLdNSPTKBFBPWa1tvtj+9HuockZwgFeD2OhxxXuC2CWeNvV4seu2o9+vbQOyQbhAM5Ez56oxUrrnTWdw==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.6.tgz",
+      "integrity": "sha512-pQPspK5H4srzlu+47+HEY2tmiY3GyYIvSPgSBdQaYVWv7t1zj1t9p1FvHlxBXyJ17t9stG/Vxj+pykrvPWBLeQ==",
       "requires": {
-        "@intlify/core-base": "9.9.1",
-        "@intlify/shared": "9.9.1",
+        "@intlify/core-base": "10.0.6",
+        "@intlify/shared": "10.0.6",
         "@vue/devtools-api": "^6.5.0"
       }
     },

--- a/view/frontend/web/js/checkout/package.json
+++ b/view/frontend/web/js/checkout/package.json
@@ -30,7 +30,7 @@
     "vite": "^4.1.2",
     "vue": "^3.4.20",
     "vue-axios": "^3.4.1",
-    "vue-i18n": "^9.1.10",
+    "vue-i18n": "^10.0.6",
     "vue-router": "^4.0.13"
   },
   "devDependencies": {


### PR DESCRIPTION
[Rendering inline script tags using secure renderer in the template file for unsafe-inline and updating vue-i18n to version 10 for unsafe-eval PCI Dss v4 compliance](https://github.com/BlueFinchCommerce/module-checkout/commit/e3f84915929f3c382392a6ea8e7a68893dcb380d)

[Add in BlueFinch Checkout layout default CSP values to mirror Luma](https://github.com/BlueFinchCommerce/module-checkout/commit/8f8923c579f1fedcfb2a7feb0b214801ab0befd9)