### PR TITLE
Remove default CSP configuration

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -20,20 +20,5 @@
                 <customer_create_success/>
             </type_for>
         </recaptcha_frontend>
-        <csp>
-            <mode>
-                <storefront_bluefinchcheckout_checkout_index>
-                    <report_only>0</report_only>
-                </storefront_bluefinchcheckout_checkout_index>
-            </mode>
-            <policies>
-                <storefront_bluefinchcheckout_checkout_index>
-                    <scripts>
-                        <inline>0</inline>
-                        <event_handlers>1</event_handlers>
-                    </scripts>
-                </storefront_bluefinchcheckout_checkout_index>
-            </policies>
-        </csp>
     </default>
 </config>


### PR DESCRIPTION
By setting the configuration within the BlueFinch Checkout module we were inadvertently changing the settings for Adobe Commerce User's <= 2.4.6. This would mean that anyone on one of those versions with inline scripts already in the checkout would start to see errors and potentially break functionality.

<!-- 

Do not commit any changes to the `view/frontend/web/js/checkout/dist` directory 

See .github/CONTRIBUTING.md for local workflow recommendations

-->
