### PR TITLE
PCI compliance changes to GTM init scripts

### DIFF
--- a/view/frontend/templates/gtag_ga.phtml
+++ b/view/frontend/templates/gtag_ga.phtml
@@ -18,7 +18,8 @@ switch ($accountType) {
             ?>
             <!-- GOOGLE TAG MANAGER -->
             <script defer src="<?= $escaper->escapeHtmlAttr($block->getViewFileUrl('BlueFinch_Checkout::js/google-tag-manager.js')) ?>"></script>
-            <script defer>
+
+            <?php $scriptString = <<<SCRIPT
                 /**
                  * @param {Object} config
                  */
@@ -34,8 +35,12 @@ switch ($accountType) {
                     document.addEventListener('user:allowed:save:cookie', function () {
                         window.bluefinchInitGtm(config);
                     });
-                })(<?= /* @noEscape */ $block->getTagManagerData() ?>)
-            </script>
+                })('{$block->getTagManagerData()}')
+                    
+                SCRIPT;
+
+            ?>
+            <?= /* @noEscape */ $secureRenderer->renderTag('script', ['defer' => 'defer'], $scriptString, false) ?>
             <!-- END GOOGLE TAG MANAGER -->
             <?php
         }
@@ -45,7 +50,8 @@ switch ($accountType) {
             ?>
             <!-- BEGIN GOOGLE ANALYTICS 4 CODE -->
             <script defer src="<?= $escaper->escapeHtmlAttr($block->getViewFileUrl('BlueFinch_Checkout::js/google-analytics.js')) ?>"></script>
-            <script defer>
+
+            <?php $scriptString = <<<SCRIPT
                 /**
                  * @param {Object} config
                  */
@@ -61,8 +67,12 @@ switch ($accountType) {
                     document.addEventListener('user:allowed:save:cookie', function () {
                         window.bluefinchInitGtm(config);
                     });
-                })(<?= /* @noEscape */ $block->getAnalyticsData() ?>)
-            </script>
+                })('{$block->getAnalyticsData()}')
+                    
+                SCRIPT;
+
+            ?>
+            <?= /* @noEscape */ $secureRenderer->renderTag('script', ['defer' => 'defer'], $scriptString, false) ?>
             <!-- END GOOGLE ANALYTICS 4 CODE -->
             <?php
         }


### PR DESCRIPTION
<!-- 

Do not commit any changes to the `view/frontend/web/js/checkout/dist` directory 

See .github/CONTRIBUTING.md for local workflow recommendations

-->

## What
The script that was being used to init gtm was contained within an inline script which errors when the CSP policy is set to not allow unsafe-inline. This PR is changing the implementation so that it uses the secure renderer within magento to prevent CSP errors

## How
- Updated the scripts for implements GTM to use the secure renderer

## Screenshot
<img width="1392" alt="Screenshot 2025-04-08 at 13 43 29" src="https://github.com/user-attachments/assets/70dc96c7-9fa5-47c6-ba31-2eb71f36b91f" />


