### PR TITLE
Fix issue with admin menu appearing down the page

### DIFF
--- a/view/adminhtml/web/js/checkout/src/styles/_core.scss
+++ b/view/adminhtml/web/js/checkout/src/styles/_core.scss
@@ -8,22 +8,6 @@
 @import "core/_button.scss";
 @import "core/_payment-method.scss";
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  position: relative;
-}
-
-body {
-  margin: 0;
-}
-
-p {
-  margin: 0;
-}
-
 #bluefinch-checkout-root {
   color: var(--font__color);
   display: flex;
@@ -35,6 +19,20 @@ p {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  *,
+  *::before,
+  *::after {
+    position: relative;
+  }
+
+  body {
+    margin: 0;
+  }
+
+  p {
+    margin: 0;
+  }
 
   .root {
     min-height: -webkit-fill-available;


### PR DESCRIPTION
Some of the styles within the admin designed were messing with all elements on the page and that caused the Adobe Commerce menu to appear lower down the page.

Removing the global styles and instead adding them to specifically within the BlueFinch container fixes the issue.

<!-- 

Do not commit any changes to the `view/frontend/web/js/checkout/dist` directory 

See .github/CONTRIBUTING.md for local workflow recommendations

-->
