### PR TITLE
added fix for datalayer helper on shipping method set

### DIFF
--- a/view/frontend/web/js/checkout/src/helpers/dataLayer/setShippingMethodDataLayer.js
+++ b/view/frontend/web/js/checkout/src/helpers/dataLayer/setShippingMethodDataLayer.js
@@ -1,14 +1,14 @@
 import useCartStore from '@/stores/CartStore';
 import useGtmStore from '@/stores/ConfigStores/GtmStore';
 
-export default () => {
+export default (carrierCode, methodCode) => {
   const gtmStore = useGtmStore();
   const { cart } = useCartStore();
   const { selected_shipping_method: selctedMethod } = cart.shipping_addresses[0];
 
   gtmStore.trackGtmEvent({
     event: 'selectShippingMethod',
-    carrierCode: selctedMethod.carrier_code,
-    methodCode: selctedMethod.method_code,
+    carrierCode: selctedMethod? selctedMethod.carrier_code : carrierCode,
+    methodCode: selctedMethod ? selctedMethod.method_code : methodCode,
   });
 };

--- a/view/frontend/web/js/checkout/src/helpers/dataLayer/setShippingMethodDataLayer.js
+++ b/view/frontend/web/js/checkout/src/helpers/dataLayer/setShippingMethodDataLayer.js
@@ -8,7 +8,7 @@ export default (carrierCode, methodCode) => {
 
   gtmStore.trackGtmEvent({
     event: 'selectShippingMethod',
-    carrierCode: selctedMethod? selctedMethod.carrier_code : carrierCode,
+    carrierCode: selctedMethod ? selctedMethod.carrier_code : carrierCode,
     methodCode: selctedMethod ? selctedMethod.method_code : methodCode,
   });
 };

--- a/view/frontend/web/js/checkout/src/stores/ShippingMethodsStore.js
+++ b/view/frontend/web/js/checkout/src/stores/ShippingMethodsStore.js
@@ -138,7 +138,7 @@ export default defineStore('shippingMethodsStore', {
         await afterSubmittingShippingInformation();
 
         // Track this event.
-        setShippingMethodDataLayer();
+        setShippingMethodDataLayer(carrierCode, methodCode);
       } catch (error) {
         this.setData({
           shippingErrorMessage: error.message,


### PR DESCRIPTION
issue is with extension shipping methods - sometimes on first checkout load set shipping method from extension module take longer to execute and datalayer helper erroring because shipping method in selected_shipping_methods is null at that moment - error quickly dissapears but we dont want to render that error as we have shipping method at this stage, so i passed data from setSippingMethod func to fallback to