### PR TITLE
Reduce GraphQL aliases in initial config (ValidationStore) to comply with Adobe alias limit

### DIFF
--- a/view/frontend/web/js/checkout/src/stores/ConfigStores/ValidationStore.js
+++ b/view/frontend/web/js/checkout/src/stores/ConfigStores/ValidationStore.js
@@ -64,30 +64,39 @@ export default defineStore('ValidationStore', {
     },
 
     getInitialConfigValues() {
-      return this.attributes.map((attribute) => (
-        `${attribute}: customAttributeMetadata(
-            attributes: [{ attribute_code: "${attribute}", entity_type: "customer_address" }]
+      // Build a single customAttributeMetadata request for ALL address attributes.
+      const attrsList = this.attributes
+        .map((attribute) => `{ attribute_code: "${attribute}", entity_type: "customer_address" }`)
+        .join(', ');
+
+      return `
+          customAttributeMetadata(
+            attributes: [${attrsList}]
           ) {
             items {
-                attribute_code
-                multiline_count
-                validate_rules {
-                  name
-                  value
-                }
+              attribute_code
+              multiline_count
+              validate_rules { name value }
             }
-          }`
-      ));
+          }`;
     },
 
     handleInitialConfig(data) {
-      this.attributes.forEach((attribute) => {
-        this.setData({
-          validationItems: {
-            [attribute]: data[attribute === 'country_code' ? 'country_id' : attribute],
-          },
-        });
+      // Map it back to our existing internal shape:
+      // validationItems = { [code]: { items: [item] } }
+      const items = data?.customAttributeMetadata?.items || [];
+
+      const map = {};
+      items.forEach((item) => {
+        const code = item.attribute_code;
+        map[code] = { items: [item] };
       });
+
+      if (map.country_id && !map.country_code) {
+        map.country_code = map.country_id;
+      }
+
+      this.setData({ validationItems: map });
     },
 
     getValidationRules(field) {


### PR DESCRIPTION
https://miro.com/app/board/uXjVLiBKOFE=/?moveToWidget=3458764643256740721&cot=14

Recent Adobe patches introduced a hard limit on the number of GraphQL aliases allowed per request (default: 10). Our checkout’s initial configuration request exceeded this limit because ValidationStore.getInitialConfigValues() generated one aliased customAttributeMetadata call per attribute (≈15 aliases). This caused the initial load to be blocked on patched environments.

**What changed**

_ValidationStore_

Replaced per-attribute aliased calls with a single customAttributeMetadata call that requests a list of attributes.

Added a mapper in handleInitialConfig to convert the response back into our existing internal structure:
validationItems = { [attribute_code]: { items: [item] } }.

Added a small backwards-compat shim: mirror country_id under country_code so existing lookups continue to work.


This change targets only the Validation block. Other initial config parts already used plain field names (0 aliases).