### PR TITLE
added new onPaymentMethodSelected function extension to pass express …

### DIFF
--- a/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/ApplePay/ApplePay.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/ApplePay/ApplePay.vue
@@ -133,7 +133,7 @@ export default {
     ...mapActions(useCustomerStore, ['submitEmail', 'setAddressToStore', 'createNewAddress']),
     ...mapActions(useBraintreeStore, ['createClientToken']),
 
-    click(event) {
+    async click(event) {
       event.preventDefault();
       this.setErrorMessage('');
       // Check that the agreements (if any) is valid.
@@ -142,7 +142,7 @@ export default {
       if (!agreementsValid) {
         return;
       }
-
+      await functionExtension('onPaymentMethodSelected', 'instant checkout - applepay');
       expressPaymentOnClickDataLayer(this.applePayConfig.code);
 
       try {

--- a/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/ApplePay/ApplePay.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/ApplePay/ApplePay.vue
@@ -142,7 +142,7 @@ export default {
       if (!agreementsValid) {
         return;
       }
-      await functionExtension('onPaymentMethodSelected', 'instant checkout - applepay');
+      await functionExtension('onExpressPaymentMethodSelected', 'instant checkout - applepay');
       expressPaymentOnClickDataLayer(this.applePayConfig.code);
 
       try {

--- a/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/ApplePay/ApplePay.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/ApplePay/ApplePay.vue
@@ -142,7 +142,7 @@ export default {
       if (!agreementsValid) {
         return;
       }
-      await functionExtension('onExpressPaymentMethodSelected', 'instant checkout - applepay');
+      await functionExtension('onPaymentMethodSelected', 'instant checkout - applepay');
       expressPaymentOnClickDataLayer(this.applePayConfig.code);
 
       try {

--- a/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/DropIn/NewMethods/NewMethods.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/DropIn/NewMethods/NewMethods.vue
@@ -78,6 +78,9 @@ import refreshCustomerData from '@/services/customer/refreshCustomerData';
 // External
 import braintreeWebDropIn from 'braintree-web-drop-in';
 
+// Extension
+import functionExtension from '@/extensions/functionExtension';
+
 export default {
   name: 'BraintreeNewMethods',
   components: {
@@ -307,9 +310,10 @@ export default {
   },
   watch: {
     selectedMethod: {
-      handler(newVal) {
+      async handler(newVal) {
         if (newVal !== null && (!newVal.startsWith('braintree')
           || newVal === 'braintree-lpm' || newVal === 'braintree-ach')) {
+          await functionExtension('onPaymentMethodSelected', newVal);
           this.clearSelectedMethod(newVal);
         }
       },
@@ -477,7 +481,7 @@ export default {
     },
 
     attachEventListeners(instance) {
-      instance.on('changeActiveView', ({ newViewId, previousViewId }) => {
+      instance.on('changeActiveView', async ({ newViewId, previousViewId }) => {
         this.removeActiveClass();
 
         this.clearErrorMessage();
@@ -485,7 +489,10 @@ export default {
         if (newViewId === 'methods') {
           this.paymentEmitter.emit('changePaymentMethodDisplay', { visible: false });
           previousViewId !== 'card' && this.startPayment();
+
+          await functionExtension('onPaymentMethodSelected', newViewId);
         } else if (newViewId !== 'options') {
+          await functionExtension('onPaymentMethodSelected', newViewId);
           this.addActiveClass(newViewId);
           const id = newViewId === 'card' ? 'braintree' : `braintree_${newViewId}`;
           this.selectPaymentMethod(id);

--- a/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/GooglePay/GooglePay.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/GooglePay/GooglePay.vue
@@ -158,7 +158,7 @@ export default {
       }
 
       this.setNotClickAndCollect();
-      await functionExtension('onPaymentMethodSelected', 'instant checkout - googlepay');
+      await functionExtension('onExpressPaymentMethodSelected', 'instant checkout - googlepay');
       const callbackIntents = ['PAYMENT_AUTHORIZATION'];
 
       if (!this.cart.is_virtual) {

--- a/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/GooglePay/GooglePay.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/GooglePay/GooglePay.vue
@@ -147,8 +147,9 @@ export default {
     ...mapActions(useConfigStore, ['getInitialConfig']),
     ...mapActions(useCustomerStore, ['submitEmail', 'createNewAddress']),
 
-    onClick(type) {
+    async onClick(type) {
       this.setErrorMessage('');
+
       // Check that the agreements (if any) is valid.
       const agreementsValid = this.validateAgreements();
 
@@ -157,7 +158,7 @@ export default {
       }
 
       this.setNotClickAndCollect();
-
+      await functionExtension('onPaymentMethodSelected', 'instant checkout - googlepay');
       const callbackIntents = ['PAYMENT_AUTHORIZATION'];
 
       if (!this.cart.is_virtual) {

--- a/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/GooglePay/GooglePay.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/GooglePay/GooglePay.vue
@@ -158,7 +158,7 @@ export default {
       }
 
       this.setNotClickAndCollect();
-      await functionExtension('onExpressPaymentMethodSelected', 'instant checkout - googlepay');
+      await functionExtension('onPaymentMethodSelected', 'instant checkout - googlepay');
       const callbackIntents = ['PAYMENT_AUTHORIZATION'];
 
       if (!this.cart.is_virtual) {

--- a/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/PayPal/PayPal.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/PayPal/PayPal.vue
@@ -173,6 +173,11 @@ export default {
               return false;
             }
 
+            const paymentTypeGta4 = this.paypal.creditActive && this.isCredit
+              ? 'instant checkout - paypal credit'
+              : 'instant checkout - paypal';
+
+            await functionExtension('onPaymentMethodSelected', paymentTypeGta4);
             await functionExtension('onBraintreeExpressInit');
             this.setNotClickAndCollect();
 

--- a/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/PayPal/PayPal.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/PayPal/PayPal.vue
@@ -177,7 +177,7 @@ export default {
               ? 'instant checkout - paypal credit'
               : 'instant checkout - paypal';
 
-            await functionExtension('onPaymentMethodSelected', paymentTypeGta4);
+            await functionExtension('onExpressPaymentMethodSelected', paymentTypeGta4);
             await functionExtension('onBraintreeExpressInit');
             this.setNotClickAndCollect();
 

--- a/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/PayPal/PayPal.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/PayPal/PayPal.vue
@@ -177,7 +177,7 @@ export default {
               ? 'instant checkout - paypal credit'
               : 'instant checkout - paypal';
 
-            await functionExtension('onExpressPaymentMethodSelected', paymentTypeGta4);
+            await functionExtension('onPaymentMethodSelected', paymentTypeGta4);
             await functionExtension('onBraintreeExpressInit');
             this.setNotClickAndCollect();
 


### PR DESCRIPTION
in order to move from UA datalayer format to GTA4 format we need to have add_payment_info event which should be triggered on click on express payment methods or standart payment methods.

for express payment methods i added onPaymentMethodSelected function extension and passed name of the payment method as instant payment - name 

added same onPaymentMethodSelected into watcher inside of braintree components to send new value of a 3rd party payment method inside of a onPaymentMethodSelected to change its type in datalayer event

for braintree regular payment method i reused this callback inside of changeActiveView to pass type of payment method selected in drop in component 
