### PR TITLE
added new config for captcha enterprise script

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -156,6 +156,16 @@
             </group>
         </section>
         <section id="recaptcha_frontend">
+            <group id="enterprise" translate="label comment" type="text" sortOrder="120" showInDefault="1"
+                   showInWebsite="1" showInStore="0">
+                <label>reCAPTCHA Enterprise</label>
+                <field id="enabled" translate="label comment" type="select" sortOrder="10" showInDefault="1"
+                       showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Enable reCAPTCHA Enterprise Script</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment><![CDATA[Use the reCAPTCHA Enterprise JavaScript API on the frontend.]]></comment>
+                </field>
+            </group>
             <group id="type_for">
                 <field id="customer_create_success" translate="label" type="select" sortOrder="132" showInDefault="1"
                        showInWebsite="1" showInStore="0" canRestore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -16,6 +16,9 @@
             </general>
         </bluefinch_checkout>
         <recaptcha_frontend>
+            <enterprise>
+                <enabled>0</enabled>
+            </enterprise>
             <type_for>
                 <customer_create_success/>
             </type_for>

--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -37,6 +37,7 @@
                 <item name="recaptcha_v2_checkbox_key" xsi:type="string">recaptcha_frontend/type_recaptcha/public_key</item>
                 <item name="recaptcha_v2_invisible_key" xsi:type="string">recaptcha_frontend/type_invisible/public_key</item>
                 <item name="recaptcha_v3_invisible_key" xsi:type="string">recaptcha_frontend/type_recaptcha_v3/public_key</item>
+                <item name="recaptcha_enterprise_enabled" xsi:type="string">recaptcha_frontend/enterprise/enabled</item>
                 <item name="recaptcha_customer_login" xsi:type="string">recaptcha_frontend/type_for/customer_login</item>
                 <item name="recaptcha_place_order" xsi:type="string">recaptcha_frontend/type_for/place_order</item>
                 <item name="recaptcha_braintree" xsi:type="string">recaptcha_frontend/type_for/braintree</item>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -32,6 +32,7 @@ type StoreConfig {
     recaptcha_v2_checkbox_key: String @doc(description: "Recaptcha v2 checkbox key")
     recaptcha_v2_invisible_key: String @doc(description: "Recaptcha v2 invisible key")
     recaptcha_v3_invisible_key: String @doc(description: "Recaptcha v3 invisible key")
+    recaptcha_enterprise_enabled: Boolean @doc(description: "Recaptcha Enterprise enabled")
     recaptcha_customer_login: String @doc(description: "Recaptcha Customer Login Type")
     recaptcha_place_order: String @doc(description: "Recaptcha Place Order Type")
     recaptcha_braintree: String @doc(description: "Recaptcha Braintree Type")
@@ -164,4 +165,3 @@ input SetAddressesOnCartInput @doc(description: "Specifies an array of addresses
     shipping_addresses: [ShippingAddressInput] @doc(description: "An array of shipping addresses.")
     billing_address: BillingAddressInput! @doc(description: "The billing address.")
 }
-

--- a/view/adminhtml/web/js/checkout/src/stores/ConfigStores/RecaptchaStore.js
+++ b/view/adminhtml/web/js/checkout/src/stores/ConfigStores/RecaptchaStore.js
@@ -7,6 +7,7 @@ export default defineStore('RecaptchaStore', {
     v2CheckboxKey: null,
     v2InvisibleKey: null,
     v3Invisible: null,
+    enterpriseEnabled: false,
     failureMessage: '',
     enabled: {
       customerLogin: false,
@@ -38,6 +39,7 @@ export default defineStore('RecaptchaStore', {
           recaptcha_v2_checkbox_key
           recaptcha_v2_invisible_key
           recaptcha_v3_invisible_key
+          recaptcha_enterprise_enabled
           recaptcha_customer_login
           recaptcha_place_order
           validation_failure_message
@@ -50,6 +52,7 @@ export default defineStore('RecaptchaStore', {
         v2CheckboxKey: storeConfig.recaptcha_v2_checkbox_key,
         v2InvisibleKey: storeConfig.recaptcha_v2_invisible_key,
         v3Invisible: storeConfig.recaptcha_v3_invisible_key,
+        enterpriseEnabled: !!storeConfig.recaptcha_enterprise_enabled,
         failureMessage: storeConfig.validation_failure_message,
         enabled: {
           customerLogin: storeConfig.recaptcha_customer_login,
@@ -67,7 +70,10 @@ export default defineStore('RecaptchaStore', {
           ? this.v3Invisible
           : 'explicit';
         const script = document.createElement('script');
-        script.src = `https://www.google.com/recaptcha/api.js?onload=bluefinchCheckoutRecaptchaLoaded&render=${render}`;
+        const scriptBaseUrl = this.$state.enterpriseEnabled
+          ? 'https://www.google.com/recaptcha/enterprise.js'
+          : 'https://www.google.com/recaptcha/api.js';
+        script.src = `${scriptBaseUrl}?onload=bluefinchCheckoutRecaptchaLoaded&render=${render}`;
         script.async = true;
         script.defer = true;
 

--- a/view/frontend/web/js/checkout/src/stores/ConfigStores/RecaptchaStore.js
+++ b/view/frontend/web/js/checkout/src/stores/ConfigStores/RecaptchaStore.js
@@ -7,6 +7,7 @@ export default defineStore('RecaptchaStore', {
     v2CheckboxKey: null,
     v2InvisibleKey: null,
     v3Invisible: null,
+    enterpriseEnabled: false,
     recaptchaId: null,
     failureMessage: '',
     enabled: {
@@ -40,6 +41,7 @@ export default defineStore('RecaptchaStore', {
           recaptcha_v2_checkbox_key
           recaptcha_v2_invisible_key
           recaptcha_v3_invisible_key
+          recaptcha_enterprise_enabled
           recaptcha_customer_login
           recaptcha_place_order
           recaptcha_braintree
@@ -53,6 +55,7 @@ export default defineStore('RecaptchaStore', {
         v2CheckboxKey: storeConfig.recaptcha_v2_checkbox_key,
         v2InvisibleKey: storeConfig.recaptcha_v2_invisible_key,
         v3Invisible: storeConfig.recaptcha_v3_invisible_key,
+        enterpriseEnabled: !!storeConfig.recaptcha_enterprise_enabled,
         failureMessage: storeConfig.validation_failure_message,
         enabled: {
           customerLogin: storeConfig.recaptcha_customer_login,
@@ -71,7 +74,10 @@ export default defineStore('RecaptchaStore', {
           ? this.v3Invisible
           : 'explicit';
         const script = document.createElement('script');
-        script.src = `https://www.google.com/recaptcha/api.js?onload=bluefinchCheckoutRecaptchaLoaded&render=${render}`;
+        const scriptBaseUrl = this.$state.enterpriseEnabled
+          ? 'https://www.google.com/recaptcha/enterprise.js'
+          : 'https://www.google.com/recaptcha/api.js';
+        script.src = `${scriptBaseUrl}?onload=bluefinchCheckoutRecaptchaLoaded&render=${render}`;
         script.async = true;
         script.defer = true;
 
@@ -102,11 +108,14 @@ export default defineStore('RecaptchaStore', {
       const placementIds = Array.isArray(ids) ? ids : [ids];
       const id = placementIds.find(this.getTypeByPlacement);
       const recapchaType = this.getTypeByPlacement(id);
+      const recaptchaApi = this.$state.enterpriseEnabled && window.grecaptcha?.enterprise
+        ? window.grecaptcha.enterprise
+        : window.grecaptcha;
 
       if (recapchaType === recapchaTypes.invisible) {
         await new Promise((resolve) => {
           if (this.$state.recaptchaId === null) {
-            const recaptchaId = window.grecaptcha.render(location, {
+            const recaptchaId = recaptchaApi.render(location, {
               sitekey: this.$state.v2InvisibleKey,
               size: 'invisible',
               callback: (token) => {
@@ -115,23 +124,23 @@ export default defineStore('RecaptchaStore', {
               },
               'error-callback': () => {
                 this.setToken(id, null);
-                window.grecaptcha.reset(recaptchaId);
+                recaptchaApi.reset(recaptchaId);
               },
               'expired-callback': () => {
                 this.setToken(id, null);
-                window.grecaptcha.reset(recaptchaId);
+                recaptchaApi.reset(recaptchaId);
               },
             });
-            window.grecaptcha.execute(recaptchaId);
+            recaptchaApi.execute(recaptchaId);
             this.setData({ recaptchaId });
           } else {
             const { recaptchaId } = this.$state;
-            window.grecaptcha.reset(recaptchaId);
-            window.grecaptcha.execute(recaptchaId).then(resolve);
+            recaptchaApi.reset(recaptchaId);
+            recaptchaApi.execute(recaptchaId).then(resolve);
           }
         });
       } else if (recapchaType === recapchaTypes.recaptchaV3) {
-        const token = await window.grecaptcha.execute(this.$state.v3Invisible, { action: 'submit' });
+        const token = await recaptchaApi.execute(this.$state.v3Invisible, { action: 'submit' });
         this.setToken(id, token);
       }
 


### PR DESCRIPTION
Add reCAPTCHA Enterprise toggle and script handling in BlueFinch checkout

Summary:

Add admin config and default setting to enable reCAPTCHA Enterprise JS
Expose enterprise toggle via StoreConfig GraphQL
Switch recaptcha loader and API calls to use enterprise when enabled 