### PR TITLE
Fix Google Pay 3DS handling for network-tokenized cards

### DIFF
--- a/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/GooglePay/GooglePay.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/PaymentPage/Braintree/GooglePay/GooglePay.vue
@@ -402,15 +402,18 @@ export default {
       billingAddress.region = billingAddress.region.region_code || billingAddress.region.region;
       const { email } = response;
       const { androidPayCards } = JSON.parse(response.paymentMethodData.tokenizationData.token);
+      const androidPayCard = androidPayCards[0];
+      const isNetworkTokenized = androidPayCard.details?.isNetworkTokenized === true;
       const price = this.cartGrandTotal / 100;
       const threshold = this.threeDSThresholdAmount;
 
-      // If 3DS is disabled or we are below the threshold then skip over this step.
-      if (!this.threeDSEnabled || price < threshold) {
+      // Network-tokenized Google Pay cards already carry cryptogram data and should not be passed to verifyCard.
+      if (!this.threeDSEnabled || price < threshold || isNetworkTokenized) {
         return Promise.resolve({
-          nonce: androidPayCards[0].nonce,
+          nonce: androidPayCard.nonce,
           billingAddress,
           email,
+          isNetworkTokenized,
         });
       }
 
@@ -427,8 +430,8 @@ export default {
 
         const threeDSecureParameters = {
           amount: parseFloat(this.cartGrandTotal / 100).toFixed(2),
-          nonce: androidPayCards[0].nonce,
-          bin: androidPayCards[0].details.bin,
+          nonce: androidPayCard.nonce,
+          bin: androidPayCard.details.bin,
           challengeRequested,
           billingAddress,
           onLookupComplete: (lookupData, next) => {
@@ -466,6 +469,7 @@ export default {
               nonce: threeDSResponse.nonce,
               billingAddress,
               email,
+              isNetworkTokenized,
             });
           } else {
             reject(new Error('Please try again with another form of payment.'));
@@ -483,6 +487,7 @@ export default {
           method: this.method,
           additional_data: {
             payment_method_nonce: response.nonce,
+            is_network_tokenized: response.isNetworkTokenized,
           },
           extension_attributes: getPaymentExtensionAttributes(),
         },


### PR DESCRIPTION
## What

Some customers intermittently hit a Google Pay checkout failure when using the instant Google Pay button at the top of checkout.

The frontend error can briefly show:

> the data passed in verifyCard did not pass validation checks. See details for more info

The Braintree response contains:

> Cannot 3D Secure a non-credit card payment instrument

This happens because the BlueFinch instant Google Pay flow attempts Braintree 3DS verification for Google Pay nonces whenever 3DS is enabled and the order is above the configured threshold. Network-tokenized Google Pay cards already include cryptogram data and should not be passed through Braintree `verifyCard`.

## How

The patch updates the instant Google Pay flow to parse the Google Pay response via Braintree’s `googlePaymentInstance.parseResponse`.

It then checks `details.isNetworkTokenized`:

- network-tokenized Google Pay cards skip `verifyCard` and use the parsed nonce directly
- non-network-tokenized Google Pay cards continue through the existing 3DS flow
- the `is_network_tokenized` flag is passed in `additional_data` so Magento/Braintree server-side handling can make the matching 3DS decision
