### PR TITLE
added fix for state field in address form

### DIFF
--- a/view/frontend/web/js/checkout/src/components/Steps/CustomerInfoPage/Addresses/AddressForms/Form/AddressForm.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/CustomerInfoPage/Addresses/AddressForms/Form/AddressForm.vue
@@ -94,7 +94,7 @@
           :options="getRegionOptions(address_type)"
           :error="showFieldError(address_type, 'region')"
           :label="$t('yourDetailsSection.deliverySection.addressForm.' +
-            'regionField.label')"
+            'stateField.label')"
           :required="getRegionRequired(address_type)"
           :data-cy="`${address_type}-state-select`"
           @change="setRegion($event)"
@@ -105,14 +105,20 @@
             v-model="selectedAddressType.postcode"
             :error="showFieldError(address_type, 'postcode')"
             :error-message="showFieldError(address_type, 'postcode')
-              ? `${$t('errorMessages.postCodeErrorMessage')} ${selectedAddressType.country_code}` : ''"
+              ? `${displayState && getRegionOptions(address_type).length
+                ? $t('errorMessages.zipCodeErrorMessage')
+                : $t('errorMessages.postCodeErrorMessage')
+              } ${selectedAddressType.country_code}`
+              : ''"
             :class="{'field-valid': selectedAddressType.postcode && isFieldValid(address_type, 'postcode'),
                      'field-error': !isFieldValid(address_type, 'postcode')}"
             type="text"
-            :placeholder="$t('yourDetailsSection.deliverySection.addressForm.' +
-              'postCodeField.placeholder')"
-            :label="$t('yourDetailsSection.deliverySection.addressForm.' +
-              'postCodeField.label')"
+            :placeholder="displayState && getRegionOptions(address_type).length
+              ? $t('yourDetailsSection.deliverySection.addressForm.' + 'zipCodeField.placeholder')
+              : $t('yourDetailsSection.deliverySection.addressForm.' + 'postCodeField.placeholder')"
+            :label="displayState && getRegionOptions(address_type).length
+              ? $t('yourDetailsSection.deliverySection.addressForm.' + 'zipCodeField.placeholder')
+              : $t('yourDetailsSection.deliverySection.addressForm.' + 'postCodeField.placeholder')"
             autocomplete="postal-code"
             :data-cy="`${address_type}-postcode-input`"
             :required="postcodeRequired(selectedAddressType.country_code)"

--- a/view/frontend/web/js/checkout/src/locales/blank.js
+++ b/view/frontend/web/js/checkout/src/locales/blank.js
@@ -125,11 +125,19 @@ export default {
           placeholder: ' ',
         },
         postCodeField: {
+          label: ' ',
+          placeholder: ' ',
+        },
+        zipCodeField: {
+          label: ' ',
           placeholder: ' ',
         },
         regionField: {
           label: ' ',
           placeholder: ' ',
+        },
+        stateField: {
+          label: ' ',
         },
       },
     },
@@ -147,6 +155,7 @@ export default {
     passwordErrorMessage: ' ',
     addressFormErrorMessage: ' ',
     postCodeErrorMessage: ' ',
+    zipCodeErrorMessage: ' ',
     countryErrorMessage: ' ',
     streetErrorMessage: ' ',
     cityErrorMessage: ' ',

--- a/view/frontend/web/js/checkout/src/locales/en-GB.js
+++ b/view/frontend/web/js/checkout/src/locales/en-GB.js
@@ -161,9 +161,16 @@ export default {
           label: 'Postcode',
           placeholder: 'Postcode',
         },
+        zipCodeField: {
+          label: 'Zip Code',
+          placeholder: 'Zip Code',
+        },
         regionField: {
           label: 'County',
           placeholder: 'County',
+        },
+        stateField: {
+          label: 'State/Province',
         },
       },
     },
@@ -186,6 +193,7 @@ export default {
     addressFormErrorMessage:
       'Please make sure that all required fields are filled',
     postCodeErrorMessage: 'Please enter a valid postcode for',
+    zipCodeErrorMessage: 'Please enter a valid zip code for',
     countryErrorMessage: 'Please choose your country',
     streetErrorMessage: 'Please enter a valid address',
     streetCharacterLimit:

--- a/view/frontend/web/js/checkout/src/locales/en-US.js
+++ b/view/frontend/web/js/checkout/src/locales/en-US.js
@@ -146,9 +146,16 @@ export default {
           label: 'Postcode',
           placeholder: 'Postcode',
         },
+        zipCodeField: {
+          label: 'Zip Code',
+          placeholder: 'Zip Code',
+        },
         regionField: {
           label: 'State/Province',
           placeholder: 'State/Province',
+        },
+        stateField: {
+          label: 'State/Province',
         },
       },
     },
@@ -171,6 +178,7 @@ export default {
     addressFormErrorMessage:
       'Please make sure that all required fields are filled',
     postCodeErrorMessage: 'Please enter a valid postcode for',
+    zipCodeErrorMessage: 'Please enter a valid zip code for',
     countryErrorMessage: 'Please choose your country',
     streetErrorMessage: 'Please enter a valid address',
     streetCharacterLimit:


### PR DESCRIPTION
When user selects in the country select something other then UK we need to make sure county select renamed to State and postcode renamed to Zip Code.