### PR TITLE
added new extension point and update for add to cart query

### DIFF
--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -35,6 +35,7 @@ We use [Vue dynamic components](https://vuejs.org/guide/essentials/component-bas
 | Extension Point                 | Usage                                              |
 | ------------------------------- | -------------------------------------------------- |
 | orderSummaryMessagesContainer   | Insert a component after order summary total       |
+| belowOrderSummary               | Insert a component after the complete order summary|
 | footerPaymentIcons              | Insert a component before the footer payment icons |
 ||
 
@@ -231,6 +232,5 @@ You also have two other options for changing styles:
 ## Remove checkout styles from your theme
 
 We recommend that you remove any unused Magento Checkout styles within your custom theme, that are not BlueFinch Checkout related, so they are not generated in the CSS for the rest of your site.
-
 
 

--- a/view/frontend/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryMobile/OrderSummaryMobile.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryMobile/OrderSummaryMobile.vue
@@ -27,6 +27,12 @@
         <OrderSummaryItem :data-cy="deviceType" />
       </div>
       <OrderSummaryTotal :data-cy="deviceType" />
+      <component
+        :is="belowOrderSummaryComponent"
+        v-for="belowOrderSummaryComponent in belowOrderSummaryComponents"
+        :key="belowOrderSummaryComponent"
+        class="below-order-summary-extension"
+      />
     </template>
   </SlideUp>
   <div
@@ -107,6 +113,7 @@ import ArrowDown from '@/components/Core/Icons/ArrowDown/ArrowDown.vue';
 
 // Helpers
 import getMagentoSolutionType from '@/helpers/getMagentoSolutionType';
+import belowOrderSummaryExtensions from '@/extensions/belowOrderSummaryExtensions';
 
 export default {
   name: 'OrderSummaryMobile',
@@ -123,6 +130,7 @@ export default {
     SlideUp,
     Close,
     OrderSummaryTitleWithAmount,
+    ...belowOrderSummaryExtensions(),
   },
   props: {
     backgroundColor: {
@@ -146,6 +154,7 @@ export default {
       orderSummaryDescriptionText: '',
       orderSummaryDescriptionTextId: 'bluefinch-checkout-ordersummarydescription-text',
       giftCardAvailable: true,
+      belowOrderSummaryComponents: [],
     };
   },
   computed: {
@@ -170,6 +179,7 @@ export default {
     await this.getCustomerInformation();
 
     this.giftCardAvailable = getMagentoSolutionType();
+    this.belowOrderSummaryComponents = Object.keys(belowOrderSummaryExtensions());
   },
   methods: {
     ...mapActions(useConfigStore, ['getInitialConfig']),

--- a/view/frontend/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryMobile/OrderSummaryMobile.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryMobile/OrderSummaryMobile.vue
@@ -27,12 +27,14 @@
         <OrderSummaryItem :data-cy="deviceType" />
       </div>
       <OrderSummaryTotal :data-cy="deviceType" />
-      <component
-        :is="belowOrderSummaryComponent"
-        v-for="belowOrderSummaryComponent in belowOrderSummaryComponents"
-        :key="belowOrderSummaryComponent"
-        class="below-order-summary-extension"
-      />
+      <template v-if="hasOpenedSummary && isMobileViewport">
+        <component
+          :is="belowOrderSummaryComponent"
+          v-for="belowOrderSummaryComponent in belowOrderSummaryComponents"
+          :key="belowOrderSummaryComponent"
+          class="below-order-summary-extension"
+        />
+      </template>
     </template>
   </SlideUp>
   <div
@@ -155,6 +157,8 @@ export default {
       orderSummaryDescriptionTextId: 'bluefinch-checkout-ordersummarydescription-text',
       giftCardAvailable: true,
       belowOrderSummaryComponents: [],
+      hasOpenedSummary: false,
+      isMobileViewport: false,
     };
   },
   computed: {
@@ -180,6 +184,9 @@ export default {
 
     this.giftCardAvailable = getMagentoSolutionType();
     this.belowOrderSummaryComponents = Object.keys(belowOrderSummaryExtensions());
+    if (this.belowOrderSummaryComponents.length > 0) {
+      this.isMobileViewport = window.matchMedia('(max-width: 768px)').matches;
+    }
   },
   methods: {
     ...mapActions(useConfigStore, ['getInitialConfig']),
@@ -188,6 +195,7 @@ export default {
     toggleSummary() {
       this.isModalVisible = !this.isModalVisible;
       if (this.isModalVisible) {
+        this.hasOpenedSummary = true;
         document.body.classList.add('no-scrollable');
       } else {
         document.body.classList.remove('no-scrollable');

--- a/view/frontend/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryMobile/styles.scss
+++ b/view/frontend/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryMobile/styles.scss
@@ -96,6 +96,11 @@
   order: var(--order-summary-order, 4);
 }
 
+.below-order-summary-extension {
+  min-width: 0;
+  order: var(--below-order-summary-order, 10);
+}
+
 //Styles for empty StoryBook data
 
 .storyBookEmptyPrice {

--- a/view/frontend/web/js/checkout/src/components/Steps/Steps.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/Steps.vue
@@ -4,6 +4,11 @@
       <div class="container">
         <div class="is-hidden-mobile summary">
           <OrderSummaryDesktop />
+          <component
+            :is="belowOrderSummaryComponent"
+            v-for="belowOrderSummaryComponent in belowOrderSummaryComponents"
+            :key="belowOrderSummaryComponent"
+          />
         </div>
         <div class="content">
           <router-view v-slot="{ Component }">
@@ -21,13 +26,21 @@
 import OrderSummaryDesktop from
   '@/components/Steps/GlobalComponents/OrderSummary/OrderSummaryDesktop/OrderSummaryDesktop.vue';
 import functionExtension from '@/extensions/functionExtension';
+import belowOrderSummaryExtensions from '@/extensions/belowOrderSummaryExtensions';
 
 export default {
   name: 'AppSteps',
   components: {
     OrderSummaryDesktop,
+    ...belowOrderSummaryExtensions(),
+  },
+  data() {
+    return {
+      belowOrderSummaryComponents: [],
+    };
   },
   async created() {
+    this.belowOrderSummaryComponents = Object.keys(belowOrderSummaryExtensions());
     await functionExtension('onStepsCreated');
   },
 };

--- a/view/frontend/web/js/checkout/src/components/Steps/Steps.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/Steps.vue
@@ -4,11 +4,13 @@
       <div class="container">
         <div class="is-hidden-mobile summary">
           <OrderSummaryDesktop />
-          <component
-            :is="belowOrderSummaryComponent"
-            v-for="belowOrderSummaryComponent in belowOrderSummaryComponents"
-            :key="belowOrderSummaryComponent"
-          />
+          <template v-if="isDesktopViewport">
+            <component
+              :is="belowOrderSummaryComponent"
+              v-for="belowOrderSummaryComponent in belowOrderSummaryComponents"
+              :key="belowOrderSummaryComponent"
+            />
+          </template>
         </div>
         <div class="content">
           <router-view v-slot="{ Component }">
@@ -37,10 +39,14 @@ export default {
   data() {
     return {
       belowOrderSummaryComponents: [],
+      isDesktopViewport: false,
     };
   },
   async created() {
     this.belowOrderSummaryComponents = Object.keys(belowOrderSummaryExtensions());
+    if (this.belowOrderSummaryComponents.length > 0) {
+      this.isDesktopViewport = window.matchMedia('(min-width: 769px)').matches;
+    }
     await functionExtension('onStepsCreated');
   },
 };

--- a/view/frontend/web/js/checkout/src/extensions/belowOrderSummaryExtensions.js
+++ b/view/frontend/web/js/checkout/src/extensions/belowOrderSummaryExtensions.js
@@ -1,0 +1,18 @@
+import { defineAsyncComponent } from 'vue';
+
+export default () => {
+  const belowOrderSummary = {};
+
+  if (window.bluefinchCheckout?.belowOrderSummary) {
+    Object.keys(window.bluefinchCheckout.belowOrderSummary).forEach((componentName) => {
+      belowOrderSummary[componentName] = defineAsyncComponent(() => (
+        import(
+          /* @vite-ignore */
+          window.bluefinchCheckout.belowOrderSummary[componentName]
+        )
+      ));
+    });
+  }
+
+  return belowOrderSummary;
+};

--- a/view/frontend/web/js/checkout/src/services/cart/addCartItem.js
+++ b/view/frontend/web/js/checkout/src/services/cart/addCartItem.js
@@ -11,20 +11,11 @@ import getEmailField from '@/helpers/cart/queryData/getEmailField';
 export default async (product) => {
   const { maskedId } = useCartStore();
   const request = `
-    mutation {
-      addSimpleProductsToCart(input: {
-        cart_id: "${maskedId}"
-        cart_items: [
-          {
-            data: {
-              sku: "${product.sku}"
-              quantity: "1"
-              selected_options: []
-              entered_options: []
-            }
-          }
-        ]
-      }) {
+    mutation BlueFinchCheckoutCartAdd($cartId: String!, $cartItems: [CartItemInput!]!) {
+      addProductsToCart(
+        cartId: $cartId
+        cartItems: $cartItems
+      ) {
         cart {
           ${await getEmailField()}
 
@@ -38,14 +29,35 @@ export default async (product) => {
 
           ${await getShippingAddresses()}
         }
+        user_errors {
+          code
+          message
+        }
       }
     }`;
-  return graphQlRequest(request, {}, {}, 'BlueFinchCheckoutCartAdd')
+  const cartItem = {
+    sku: product.sku,
+    quantity: product.quantity || 1,
+    selected_options: [],
+    entered_options: [],
+  };
+  if (product.parent_sku) {
+    cartItem.parent_sku = product.parent_sku;
+  }
+
+  return graphQlRequest(request, {
+    cartId: maskedId,
+    cartItems: [cartItem],
+  }, {}, 'BlueFinchCheckoutCartAdd')
     .then((response) => {
       if (response.errors) {
         throw new Error(response.errors[0].message);
       }
+      const userErrors = response.data.addProductsToCart.user_errors;
+      if (userErrors.length) {
+        throw new Error(userErrors[0].message);
+      }
 
-      return response.data.addSimpleProductsToCart.cart;
+      return response.data.addProductsToCart.cart;
     });
 };

--- a/view/frontend/web/js/checkout/src/stores/CartStore.js
+++ b/view/frontend/web/js/checkout/src/stores/CartStore.js
@@ -203,6 +203,7 @@ export default defineStore('cartStore', {
         const cart = await updateCartItemQuantity(updateItem, change);
         this.handleCartData(cart);
         this.emitUpdate();
+        window.dispatchEvent(new CustomEvent('bluefinch-checkout-cart-items-updated'));
       } catch (error) {
         // Add the error message to the cart item.
         const { items } = this.cart;
@@ -245,6 +246,7 @@ export default defineStore('cartStore', {
         const cart = await removeCartItem(product.uid);
         this.handleCartData(cart);
         this.emitUpdate();
+        window.dispatchEvent(new CustomEvent('bluefinch-checkout-cart-items-updated'));
       } catch (error) {
         console.warn('Unable to remove cart item', error.message);
       }
@@ -360,6 +362,7 @@ export default defineStore('cartStore', {
         const cart = await addCartItem(product);
         this.handleCartData(cart);
         this.emitUpdate();
+        window.dispatchEvent(new CustomEvent('bluefinch-checkout-cart-items-updated'));
       } catch (error) {
         console.warn('Unable to add cart item', error.message);
       }


### PR DESCRIPTION
- Added a belowOrderSummary extension point for components rendered beneath the complete order summary.
- Added support for the extension on desktop and inside the mobile Order Summary drawer.
- Prevented duplicate desktop/mobile Nosto placements.
- Deferred mobile recommendations until Order Summary is first opened.
- Kept the mobile placement mounted after closing to avoid react portal reconciliation errors.
- Added a BlueFinch cart-items-updated event after successful add, remove and quantity changes.
- Added support for parent_sku in BlueFinch’s generic addProductsToCart request, allowing configurable recommendation products to be added correctly.