### PR TITLE
added extension point for order summary item

### DIFF
--- a/view/frontend/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryItem/OrderSummaryItem.vue
+++ b/view/frontend/web/js/checkout/src/components/Steps/GlobalComponents/OrderSummary/OrderSummaryItem/OrderSummaryItem.vue
@@ -18,6 +18,21 @@
             :text="item?.product?.name"
             :data-cy="dataCy ? `product-name-${dataCy}` : 'product-name'"
           />
+          <div
+            v-if="item?.order_summary_messages?.length"
+            class="order-summary-item-messages"
+          >
+            <p
+              v-for="(message, messageIndex) in item.order_summary_messages"
+              :key="message.id || messageIndex"
+              class="order-summary-item-message"
+              :class="[
+                message.className,
+                `order-summary-item-message--${message.type || 'info'}`,
+              ]"
+              v-text="message.text"
+            />
+          </div>
           <ProductOptions
             v-if="item?.configurable_options || item?.customizable_options"
             :item="item"

--- a/view/frontend/web/js/checkout/src/helpers/cart/queryData/getItems.js
+++ b/view/frontend/web/js/checkout/src/helpers/cart/queryData/getItems.js
@@ -49,6 +49,11 @@ export default async () => {
     `;
   }
 
+  const [additionalItemFields = ''] = await functionExtension(
+    'getCartItemAdditionalFields',
+    [''],
+  );
+
   // Build the full cart items query string
   const items = `
     items {
@@ -94,6 +99,7 @@ export default async () => {
         }
       }
       quantity
+      ${additionalItemFields}
       errors {
         code
         message


### PR DESCRIPTION
Adds a generic getCartItemAdditionalFields extension point for integrations to append fields to the GraphQL cart-item query without replacing or modifying the complete query.

Adds support for rendering optional order_summary_messages beneath product names in the checkout order summary.

Renders message text safely using v-text.

Keeps the functionality integration-agnostic with no dependency on Amasty or other third-party modules.

Preserves existing checkout behaviour when no extensions or item messages are provided.