### PR TITLE
added downloadable product to be accepted as virtual

### DIFF
--- a/view/frontend/web/js/checkout/src/helpers/cart/getCartItems.js
+++ b/view/frontend/web/js/checkout/src/helpers/cart/getCartItems.js
@@ -1,7 +1,7 @@
 export default () => {
   const mageCache = JSON.parse(localStorage.getItem('mage-cache-storage'));
 
-  if (!mageCache.cart) {
+  if (!mageCache?.cart?.items) {
     return [];
   }
   return mageCache.cart.items.map((item) => ({
@@ -19,7 +19,7 @@ export default () => {
       },
       giftMessage: {},
     },
-    configurable_options: item.options.map((option) => ({
+    configurable_options: (item.options || []).map((option) => ({
       options_label: option.label,
       value_label: option.value,
     })),

--- a/view/frontend/web/js/checkout/src/helpers/cart/getCartPrices.js
+++ b/view/frontend/web/js/checkout/src/helpers/cart/getCartPrices.js
@@ -1,7 +1,7 @@
 export default () => {
   const mageCache = JSON.parse(localStorage.getItem('mage-cache-storage'));
 
-  if (!mageCache.cart) {
+  if (!mageCache?.cart) {
     return {
       subtotalAmount: 0,
       grandTotalAmount: 0,

--- a/view/frontend/web/js/checkout/src/helpers/cart/getIsVirtual.js
+++ b/view/frontend/web/js/checkout/src/helpers/cart/getIsVirtual.js
@@ -5,5 +5,9 @@ export default () => {
     return false;
   }
 
-  return !mageCache.cart.items.some(({ product_type: productType }) => productType !== 'virtual');
+  const virtualProductTypes = ['virtual', 'downloadable'];
+
+  return mageCache.cart.items.every(({ product_type: productType }) => (
+    virtualProductTypes.includes(productType)
+  ));
 };

--- a/view/frontend/web/js/checkout/src/stores/CartStore.js
+++ b/view/frontend/web/js/checkout/src/stores/CartStore.js
@@ -44,6 +44,9 @@ export default defineStore('cartStore', {
       items: getCartItems(),
       prices: getCartPrices(),
       is_virtual: getIsVirtual(),
+      shipping_addresses: [],
+      available_payment_methods: [],
+      applied_coupons: [],
     },
     customer_is_guest: null,
     subtotalInclTax: null,
@@ -185,12 +188,12 @@ export default defineStore('cartStore', {
         customerStore.setAddressToStore(cart.billing_address, 'billing');
       }
 
-      if (cart.shipping_addresses.length) {
+      if (cart.shipping_addresses?.length) {
         customerStore.setAddressToStore(cart.shipping_addresses[0], 'shipping');
         shippingMethodsStore.setShippingDataFromCartData(cart);
       }
 
-      if (cart.available_payment_methods) {
+      if (cart.available_payment_methods?.length) {
         paymentStore.setPaymentMethods(cart.available_payment_methods);
       }
     },

--- a/view/frontend/web/js/checkout/src/stores/PaymentStores/PaymentStore.js
+++ b/view/frontend/web/js/checkout/src/stores/PaymentStores/PaymentStore.js
@@ -55,11 +55,13 @@ export default defineStore('paymentStore', {
     },
 
     setPaymentMethods(paymentMethods) {
+      const availableMethods = Array.isArray(paymentMethods) ? paymentMethods : [];
+
       this.setData({
-        availableMethods: paymentMethods,
+        availableMethods,
       });
 
-      this.selectPaymentMethod(paymentMethods[0].code);
+      this.selectPaymentMethod(availableMethods[0]?.code ?? null);
     },
 
     selectPaymentMethod(selectedMethod) {


### PR DESCRIPTION
Updated BlueFinch checkout to support downloadable products correctly:
- Treat downloadable products as virtual, so they don’t require shipping.
- Handle free downloadable products with no available payment methods.
- Prevent errors when shipping, payment, coupon, or product-option data is empty.
- Rebuilt the checkout frontend assets.
- 
Paid downloadable products will continue through the normal payment flow.